### PR TITLE
Sped up website loads with effective nginx gzipping.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,8 @@ COPY package.json yarn.lock ./
 ## Storing node modules on a separate layer will prevent unnecessary npm installs at each build
 ## Necessary for bundling python, make, and g++ tools under the name .gyp, using it for yarn install,
 ## and then removing .gyp at the end of the install process.
-RUN apk add --no-cache --virtual .gyp \
-  python \
-  make \
-  g++ \
-  && yarn install && mkdir /usr/app/ng-app && cp -R ./node_modules ./ng-app \
-  && apk del .gyp
+RUN yarn install
+RUN mkdir /usr/app/ng-app && cp -R ./node_modules ./ng-app
 
 WORKDIR /usr/app/ng-app
 
@@ -47,4 +43,5 @@ RUN rm -rf /usr/share/nginx/html/*
 ## From 'builder' stage copy over the artifacts in dist folder to default nginx public folder
 COPY --from=builder /usr/app/ng-app/dist /usr/share/nginx/html
 
+# daemon off sets global configuration option that runs nginx in foreground for this container
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -44,7 +44,7 @@ http {
 
         location / {
             gzip on;
-            gzip_types ~text/ ~image/ ~audio/ ~video/ ~application/;
+            gzip_types application/javascript text/css text/html ~text/ ~image/ ~audio/ ~video/ ~application/;
             gzip_comp_level 2;
             gzip_http_version 1.0;
             gzip_proxied any;
@@ -55,6 +55,7 @@ http {
             gzip_disable "MSIE [1-6].(?!.*SV1)";
 
             # Add a vary header for downstream proxies to avoid sending cached gzipped files to IE6
+            # explanation of vary header here: https://blog.stackpath.com/accept-encoding-vary-important/
             gzip_vary on;
 
             expires $expires;
@@ -66,7 +67,7 @@ http {
             try_files $uri $uri/ /index.html =404;
         }
 
-        # Trailing / matters 
+        # Trailing / matters
         location /api/ {
             proxy_pass http://api_server/api/;
         }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,6 +2,6 @@ export const environment = {
   production: true,
 
   mapbox: {
-    accessToken: 'pk.eyJ1IjoidHJpbmFrYXQiLCJhIjoiY2phczZjMDRoNG9lMTMxbnEzMnAyemtqMyJ9.9BNijLx_oyyU2LmboUczTw' // 'pk.eyJ1IjoiaGVsYXJhYmF3eSIsImEiOiJjajUxN3k2d3MwMGg4MnFxZHhjcjYxN2U4In0.0OSl71QURA_P9d32r982Zw';
+    accessToken: 'pk.eyJ1IjoidHJpbmFrYXQiLCJhIjoiY2phczZjMDRoNG9lMTMxbnEzMnAyemtqMyJ9.9BNijLx_oyyU2LmboUczTw'
   }
 };

--- a/src/index.html
+++ b/src/index.html
@@ -15,9 +15,7 @@
   <meta name="viewport" content="viewport-fit=cover, width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <link rel="icon" type="image/x-icon" href="assets/favicons/favicon.ico">
   <link href="https://fonts.googleapis.com/css?family=Lato:400,500,600" rel="stylesheet">
-  <!-- <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script> -->
   <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" rel="stylesheet">
-  <!-- <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" /> -->
   <!-- PWA Factors -->
   <meta name="theme-color" content="#53D8D8">
   <link rel="manifest" href="manifest.json">
@@ -28,7 +26,6 @@
   </style>
 </head>
 <body>
-  <!-- <nav class="navbar navbar-toggleable-md  navbar-default"></nav> -->
   <div class="temp-nav"></div>
   <noscript><div>Your browser does not support JavaScript</div></noscript>
   <app-root>


### PR DESCRIPTION
Yeah....I don't think the ~[folder_name]/ syntax actually does anything: large js files weren't being gzipped, whereas now they seem to be, shaving some load time. The rest of the changes are getting rid of comments and speeding up the docker container build by improving caching and removing cruft.